### PR TITLE
Fix target elusive memory issues

### DIFF
--- a/ibis.yml
+++ b/ibis.yml
@@ -12,7 +12,7 @@ dependencies:
   - bird_tool_utils_python=0.4.*
   - extern=0.4.*
   - ruamel.yaml=0.17.*
-  - polars=0.17.*
+  - polars=0.18.*
   - pyarrow=12.0.*
   - parallel=20230522
   - pyopenssl>22.1.0 # see https://github.com/pyca/cryptography/issues/7959#issuecomment-1368711852

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0beta1"
+__version__ = "0.9.0beta2"

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0beta2"
+__version__ = "0.9.0beta3"

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0beta3"
+__version__ = "0.9.0beta4"

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.0"
+__version__ = "0.9.0beta1"

--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -384,6 +384,11 @@ def coassemble(args):
         snakemake_args = args.snakemake_args,
     )
 
+    logging.info(f"Ibis coassemble complete.")
+    logging.info(f"Cluster summary at {os.path.join(args.output, 'coassemble', 'summary.tsv')}")
+    logging.info(f"More details at {os.path.join(args.output, 'coassemble', 'target', 'elusive_clusters.tsv')}")
+    logging.info(f"Aviary commands for coassembly and recovery in shell scripts at {os.path.join(args.output, 'coassemble', 'commands')}")
+
 def evaluate(args):
     coassemble_dir = os.path.abspath(args.coassemble_output)
     coassemble_target_dir = os.path.join(coassemble_dir, "target")
@@ -435,6 +440,10 @@ def evaluate(args):
         snakemake_args = args.snakemake_args,
     )
 
+    logging.info(f"Ibis evaluate complete.")
+    logging.info(f"Coassembly evaluation summary at {os.path.join(args.output, 'evaluate', 'evaluate', 'summary_stats.tsv')}")
+    logging.info(f"Genome recovery breakdown by phyla at {os.path.join(args.output, 'evaluate', 'evaluate', 'plots', 'combined', 'phylum_recovered.png')}")
+
 def update(args):
     logging.info("Loading Ibis coassemble info")
     if args.coassemble_output:
@@ -474,6 +483,9 @@ def update(args):
 
     args = set_standard_args(args)
     coassemble(args)
+
+    logging.info(f"Ibis update complete.")
+    logging.info(f"Aviary commands for coassembly and recovery in shell scripts at {os.path.join(args.output, 'coassemble', 'commands')}")
 
 def generate_genome_singlem(orig_args, new_genomes):
     args = copy.deepcopy(orig_args)
@@ -530,6 +542,11 @@ def iterate(args):
                     )
     else:
         logging.warn("Suggested coassemblies may match those from previous iterations. To check, use `--elusive-clusters`.")
+
+    logging.info(f"Ibis iterate complete.")
+    logging.info(f"Cluster summary at {os.path.join(args.output, 'coassemble', 'summary.tsv')}")
+    logging.info(f"More details at {os.path.join(args.output, 'coassemble', 'target', 'elusive_clusters.tsv')}")
+    logging.info(f"Aviary commands for coassembly and recovery in shell scripts at {os.path.join(args.output, 'coassemble', 'commands')}")
 
 def build(args):
     output_dir = os.path.join(args.output, "build")
@@ -600,6 +617,9 @@ def build(args):
     args.forward = ["SRR8334323", "SRR8334324"]
     args.reverse = args.forward
     update(args)
+
+    logging.info(f"Ibis build complete.")
+    logging.info(f"Conda envs at {conda_prefix}")
 
 def main():
     main_parser = btu.BirdArgparser(program="Ibis (bin chicken)", version = __version__, program_invocation="ibis",

--- a/ibis/workflow/env/aviary.yml
+++ b/ibis/workflow/env/aviary.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - python>=3.7
-  - aviary>=0.5.7
+  - aviary=0.5.*

--- a/ibis/workflow/env/coverm.yml
+++ b/ibis/workflow/env/coverm.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - python>=3.6
-  - coverm
+  - coverm=0.6.*

--- a/ibis/workflow/env/kingfisher.yml
+++ b/ibis/workflow/env/kingfisher.yml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - rpetit3
 dependencies:
-  - kingfisher>=0.2.1
+  - kingfisher=0.2.*
   - aspera-connect

--- a/ibis/workflow/env/prodigal.yml
+++ b/ibis/workflow/env/prodigal.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - python>=3.6
-  - prodigal
+  - prodigal=2.6.*

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -38,7 +38,7 @@ def pipeline(
     )
 
     # Start with pair clusters
-    clusters = [elusive_edges.lazy().filter(pl.col("length") == 2).select("samples", "target_ids", sample = pl.col("samples"))]
+    clusters = [elusive_edges.filter(pl.col("length") == 2).select("samples", "target_ids", sample = pl.col("samples"))]
     for n in range(3, MAX_COASSEMBLY_SAMPLES + 1):
         # Join pairs to n-1 clusters and add n clusters from elusive_edges
         clusters.append(
@@ -55,7 +55,6 @@ def pipeline(
                 .filter(pl.col("samples").list.lengths() == n),
                 # n-way edges
                 elusive_edges
-                .lazy()
                 .filter(pl.col("length") == n)
                 .select("samples", "target_ids", n_way_edge = True)
             ])
@@ -75,7 +74,6 @@ def pipeline(
     if MAX_COASSEMBLY_SAMPLES == 1:
         clusters = [
             elusive_edges
-            .lazy()
             .explode("samples")
             .groupby("samples")
             .agg(pl.col("target_ids").flatten())
@@ -117,7 +115,7 @@ def pipeline(
             length = pl.col("samples").list.lengths()
             )
         .explode("sample")
-        .join(read_size.lazy(), on="sample", how="inner")
+        .join(read_size, on="sample", how="inner")
         .groupby("samples")
         .agg(
             pl.first("length"),
@@ -162,7 +160,6 @@ def pipeline(
             "samples", "length", "total_targets", "total_size", "recover_samples",
             coassembly = pl.lit("coassembly_") + pl.col("coassembly").cast(pl.Utf8)
             )
-        .collect()
     )
 
     return clusters

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -65,6 +65,19 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
         .with_columns(pl.col(output_colname).fill_null([]))
         )
 
+def accumulate_clusters(x):
+    clustered_samples = []
+    choices = []
+    for cluster in x:
+        cluster_samples = cluster.split(",")
+        if all([x not in clustered_samples for x in cluster_samples]):
+            choices.append(True)
+            clustered_samples += cluster_samples
+        else:
+            choices.append(False)
+
+    return pl.Series(choices, dtype=pl.Boolean)
+
 def pipeline(
         elusive_edges,
         read_size,
@@ -144,18 +157,7 @@ def pipeline(
                 )
         ])
 
-    def accumulate_clusters(x):
-        clustered_samples = []
-        choices = []
-        for cluster in x:
-            cluster_samples = cluster.split(",")
-            if all([x not in clustered_samples for x in cluster_samples]):
-                choices.append(True)
-                clustered_samples += cluster_samples
-            else:
-                choices.append(False)
-
-        return pl.Series(choices, dtype=pl.Boolean)
+        #return clusters.collect(streaming=True)
 
     sample_targets = (
         elusive_edges

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -34,7 +34,7 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
         df2_phys = (
             df2.select(
                 pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical().list.sort(),
-                pl.col(value_colname).flatten(),
+                pl.col(value_colname),
                 )
             .with_row_count()
         )
@@ -55,7 +55,7 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
             )
             .filter(pl.col(list_colname).hash() == pl.col(list_colname + '_right').hash())
             .groupby('row_nr')
-            .agg(value_colname)
+            .agg(pl.col(value_colname).flatten())
             .select("row_nr", pl.col(value_colname).alias(output_colname))
         )
 

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -34,7 +34,7 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
         df2_phys = (
             df2.select(
                 pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical().list.sort(),
-                pl.col(value_colname),
+                pl.col(value_colname).flatten(),
                 )
             .with_row_count()
         )

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -86,13 +86,13 @@ def find_recover_candidates(df, samples_df, MAX_RECOVERY_SAMPLES=20):
         .select("join_col", "target_ids")
         .explode("target_ids")
         .join(samples_df, on="target_ids", how="left")
-        .groupby("join_col", "samples")
+        .groupby("join_col", "recover_candidates")
         .agg(pl.count())
         .sort("count", descending=True)
         .groupby("join_col")
         .head(MAX_RECOVERY_SAMPLES)
         .groupby("join_col")
-        .agg(recover_candidates = pl.col("samples"))
+        .agg("recover_candidates")
     )
 
     return (
@@ -201,11 +201,11 @@ def pipeline(
 
         sample_targets = (
             elusive_edges
-            .select("samples", "target_ids")
-            .explode("samples")
+            .select("target_ids", recover_candidates = pl.col("samples"))
+            .explode("recover_candidates")
             .explode("target_ids")
             .unique()
-            .groupby("samples")
+            .groupby("recover_candidates")
             .agg("target_ids")
         )
 

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -26,14 +26,14 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
     with pl.StringCache():
         df1_phys = (
             df1.select(
-                pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical().list.sort(),
+                pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical(),
                 "row_nr",
                 )
         )
 
         df2_phys = (
             df2.select(
-                pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical().list.sort(),
+                pl.col(list_colname).cast(pl.List(pl.Categorical)).to_physical(),
                 pl.col(value_colname),
                 )
             .with_row_count()

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -186,7 +186,7 @@ def pipeline(
                             else:
                                 cluster_combinations[samples].update(row["target_ids"])
 
-                    for samples in cluster_combinations:
+                    for samples in list(cluster_combinations.keys()):
                         extra_targets = (
                             elusive_edges
                             .filter(pl.col("samples").list.eval(pl.element().is_in(samples)).list.all())

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -85,7 +85,7 @@ def pipeline(
         .lazy()
         .with_columns(
             pl.col("samples").str.split(",").list.eval(pl.element().str.replace(r"\.1$", "")),
-            pl.col("target_ids").str.split(","),
+            pl.col("target_ids").str.split(",").cast(pl.List(pl.UInt32)),
             )
         .with_columns(length = pl.col("samples").list.lengths())
     )
@@ -161,7 +161,7 @@ def pipeline(
     sample_targets = (
         elusive_edges
         .lazy()
-        .select("samples", "target_ids")
+        .select("samples", pl.col("target_ids").cast(pl.List(pl.Utf8)))
         .explode("samples")
         .explode("target_ids")
         .unique(["samples", "target_ids"])
@@ -172,7 +172,7 @@ def pipeline(
         clusters
         .with_columns(
             pl.col("samples").list.sort().list.join(","),
-            pl.col("target_ids").list.sort().list.join(","),
+            pl.col("target_ids").cast(pl.List(pl.Utf8)).list.sort().list.join(","),
             total_targets = pl.col("target_ids").list.lengths(),
             length = pl.col("samples").list.lengths()
             )

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -68,12 +68,15 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
         )
 
 def accumulate_clusters(x):
-    clustered_samples = set()
+    clustered_samples = {}
     choices = []
     for cluster in x:
-        if all([x not in clustered_samples for x in cluster]):
+        cluster_size = len(cluster)
+        if cluster_size not in clustered_samples:
+            clustered_samples[cluster_size] = set()
+        if all([s not in clustered_samples[cluster_size] for s in cluster]):
             choices.append(True)
-            clustered_samples.update(cluster)
+            clustered_samples[cluster_size].update(cluster)
         else:
             choices.append(False)
 

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -237,7 +237,7 @@ def pipeline(
                 .then(pl.col("total_size") <= MAX_COASSEMBLY_SIZE)
                 .otherwise(True)
                 )
-            .sort("total_targets", descending=True)
+            .sort("total_targets", pl.col("samples").hash(), descending=True)
             .with_columns(
                 unique_samples = 
                     pl.col("samples")

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -81,7 +81,7 @@ def accumulate_clusters(x):
 
 def find_recover_candidates(df, samples_df, MAX_RECOVERY_SAMPLES=20):
     samples_df = samples_df.explode("target_ids")
-    df = df.with_columns(join_col = pl.col("samples").hash())
+    df = df.with_columns(join_col = pl.col("samples").list.sort().hash())
 
     output = (
         df

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -184,6 +184,7 @@ def pipeline(
                     .select("samples_hash", "samples", "target_ids")
                     .groupby("samples_hash")
                     .agg(pl.first("samples"), pl.col("target_ids").flatten())
+                    .filter(pl.col("target_ids").list.lengths() >= MIN_CLUSTER_TARGETS)
                     .pipe(
                         join_list_subsets,
                         df2=elusive_edges,
@@ -197,7 +198,6 @@ def pipeline(
                         pl.concat_list("target_ids", "extra_targets").list.unique(),
                         "samples_hash",
                         )
-                    .filter(pl.col("target_ids").list.lengths() >= MIN_CLUSTER_TARGETS)
                 )
 
         sample_targets = (
@@ -259,7 +259,7 @@ def pipeline(
                 "samples", "length", "total_targets", "total_size", "recover_samples",
                 coassembly = pl.lit("coassembly_") + pl.col("coassembly").cast(pl.Utf8)
                 )
-            .collect(streaming=True, projection_pushdown=False)
+            .collect(streaming=True)
         )
 
     logging.info("Done")

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -69,10 +69,9 @@ def accumulate_clusters(x):
     clustered_samples = set()
     choices = []
     for cluster in x:
-        cluster_samples = cluster.split(",")
-        if all([x not in clustered_samples for x in cluster_samples]):
+        if all([x not in clustered_samples for x in cluster]):
             choices.append(True)
-            clustered_samples.update(cluster_samples)
+            clustered_samples.update(cluster)
         else:
             choices.append(False)
 

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -170,49 +170,39 @@ def pipeline(
             ]
 
             if is_pooled:
-                    cluster_combinations = {}
-                    for row in (
-                        elusive_edges
-                        .filter(pl.col("style") == "pool")
-                        .collect()
-                        .iter_rows(named=True)
-                        ):
-
-                        for cluster in itertools.combinations(row["samples"], row["cluster_size"]):
-                            samples = frozenset(cluster)
-
-                            if samples not in cluster_combinations:
-                                cluster_combinations[samples] = set(row["target_ids"])
-                            else:
-                                cluster_combinations[samples].update(row["target_ids"])
-
-                    for samples in list(cluster_combinations.keys()):
-                        extra_targets = (
-                            elusive_edges
-                            .filter(pl.col("samples").list.eval(pl.element().is_in(samples)).list.all())
-                            .groupby(1)
-                            .agg(pl.col("target_ids").flatten())
-                            .collect()
-                            .get_column("target_ids")
-                            .to_list()[0]
+                clusters.append(
+                    elusive_edges
+                    .filter(pl.col("style") == "pool")
+                    # Prevent combinatorial explosion (also, large clusters are less useful for distinguishing between clusters)
+                    .filter(pl.col("samples").list.lengths() < 100)
+                    .with_columns(
+                        samples_combinations = pl.struct(["length", "cluster_size"]).apply(
+                            lambda x: [i for i in itertools.combinations(range(x["length"]), x["cluster_size"])],
+                            return_dtype=pl.List(pl.List(pl.Int64)),
+                            )
                         )
-
-                        cluster_combinations[samples].update(extra_targets)
-
-                        if len(cluster_combinations[samples]) < MIN_CLUSTER_TARGETS:
-                            _ = cluster_combinations.pop(samples)
-
-                    clusters.append(
-                        pl.LazyFrame(
-                            [[list(k),list(v)] for k,v in cluster_combinations.items()],
-                            schema = {"samples": pl.List(pl.Categorical), "target_ids": pl.List(pl.UInt32)},
-                            orient="row",
-                            )
-                        .select(
-                            "samples", "target_ids",
-                            sample = pl.col("samples"),
-                            )
-                    )
+                    .explode("samples_combinations")
+                    .with_columns(
+                        pl.col("samples")
+                        .list.take(pl.col("samples_combinations"))
+                        )
+                    .select("samples", "target_ids")
+                    .groupby("samples")
+                    .agg(pl.col("target_ids").flatten())
+                    .filter(pl.col("target_ids").list.lengths() >= MIN_CLUSTER_TARGETS)
+                    .pipe(
+                        join_list_subsets,
+                        df2=elusive_edges,
+                        list_colname="samples",
+                        value_colname="target_ids",
+                        output_colname="extra_targets"
+                        )
+                    .select(
+                        "samples",
+                        pl.concat_list("target_ids", "extra_targets").list.unique(),
+                        sample = pl.col("samples"),
+                        )
+                )
 
         sample_targets = (
             elusive_edges

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -287,6 +287,11 @@ if __name__ == "__main__":
     elusive_edges = pl.read_csv(elusive_edges_path, separator="\t", dtypes={"target_ids": str})
     read_size = pl.read_csv(read_size_path, has_header=False, new_columns=["sample", "read_size"])
 
+    if elusive_edges.height > 10**4:
+        min_cluster_targets = 10
+    else:
+        min_cluster_targets = 1
+
     clusters = pipeline(
         elusive_edges,
         read_size,
@@ -294,6 +299,6 @@ if __name__ == "__main__":
         MAX_COASSEMBLY_SAMPLES=MAX_COASSEMBLY_SAMPLES,
         MIN_COASSEMBLY_SAMPLES=MIN_COASSEMBLY_SAMPLES,
         MAX_RECOVERY_SAMPLES=MAX_RECOVERY_SAMPLES,
-        MIN_CLUSTER_TARGETS=10,
+        MIN_CLUSTER_TARGETS=min_cluster_targets,
         )
     clusters.write_csv(elusive_clusters_path, separator="\t")

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -224,7 +224,7 @@ def pipeline(
                 )
             .filter(pl.col("length") >= MIN_COASSEMBLY_SAMPLES)
             .explode("sample")
-            .join(read_size, on="sample", how="inner")
+            .join(read_size, on="sample", how="left")
             .groupby("samples")
             .agg(
                 pl.first("length"),

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -181,6 +181,12 @@ if __name__ == "__main__":
     os.environ["POLARS_MAX_THREADS"] = str(snakemake.threads)
     import polars as pl
 
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s',
+        datefmt='%Y/%m/%d %I:%M:%S %p'
+        )
+
     MAX_COASSEMBLY_SIZE = snakemake.params.max_coassembly_size * 10**9 if snakemake.params.max_coassembly_size else None
     MAX_COASSEMBLY_SAMPLES = snakemake.params.max_coassembly_samples
     MIN_COASSEMBLY_SAMPLES = snakemake.params.num_coassembly_samples

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -155,9 +155,9 @@ def pipeline(
                 .groupby("samples")
                 .agg(pl.col("target_ids").flatten())
                 .with_columns(
-                    pl.col("samples").apply(lambda x: [x], return_dtype=pl.List(pl.Utf8)).cast(pl.List(pl.Categorical)),
+                    pl.concat_list(pl.col("samples")),
                     pl.col("target_ids").list.sort().list.unique(),
-                    sample = pl.col("samples").apply(lambda x: [x], return_dtype=pl.List(pl.Utf8)).cast(pl.List(pl.Categorical)),
+                    sample = pl.concat_list(pl.col("samples")),
                 )
             ]
         else:

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -66,13 +66,13 @@ def join_list_subsets(df1, df2, list_colname, value_colname, output_colname):
         )
 
 def accumulate_clusters(x):
-    clustered_samples = []
+    clustered_samples = set()
     choices = []
     for cluster in x:
         cluster_samples = cluster.split(",")
         if all([x not in clustered_samples for x in cluster_samples]):
             choices.append(True)
-            clustered_samples += cluster_samples
+            clustered_samples.update(cluster_samples)
         else:
             choices.append(False)
 

--- a/ibis/workflow/scripts/cluster_graph.py
+++ b/ibis/workflow/scripts/cluster_graph.py
@@ -163,7 +163,6 @@ def pipeline(
                 # Pair clusters
                 elusive_edges
                 .filter(pl.col("style") == "match")
-                .filter(pl.col("length") == 2)
                 .filter(pl.col("target_ids").list.lengths() >= MIN_CLUSTER_TARGETS)
                 .select("samples", "target_ids", sample = pl.col("samples"))
             ]

--- a/ibis/workflow/scripts/collect_reference_bins.py
+++ b/ibis/workflow/scripts/collect_reference_bins.py
@@ -59,9 +59,9 @@ def pipeline(appraise_binned, appraise_unbinned, sample, MIN_APPRAISED=0.1, TRIM
         (pl.col("coverage").len() * TRIM_FRACTION).floor().cast(int).alias("cut"),
         pl.col("coverage")
     ).with_columns(
-        pl.col("coverage").arr.sort().arr.slice(
-            pl.col("cut"), pl.col("coverage").arr.lengths() - 2 * pl.col("cut")
-            ).arr.mean()
+        pl.col("coverage").list.sort().list.slice(
+            pl.col("cut"), pl.col("coverage").list.lengths() - 2 * pl.col("cut")
+            ).list.mean()
     ).filter(
         pl.col("coverage") > 0
     ).get_column("found_in"

--- a/ibis/workflow/scripts/evaluate.py
+++ b/ibis/workflow/scripts/evaluate.py
@@ -111,7 +111,7 @@ def evaluate(target_otu_table, binned_otu_table, elusive_clusters, elusive_edges
 
     # Load recovered otu table and join elusive and nontarget sequences
     recovered_otu_table = recovered_otu_table.with_columns(
-        pl.col("sample").str.split("-").arr.to_struct(upper_bound=2, fields=["coassembly", "genome"])
+        pl.col("sample").str.split("-").list.to_struct(upper_bound=2, fields=["coassembly", "genome"])
     ).unnest("sample"
     )
 
@@ -205,7 +205,7 @@ def summarise_stats(matches, combined_otu_table, recovered_bins):
     recovered_counts = pl.from_dict(recovered_bins
     ).melt(variable_name="name"
     ).with_columns(
-        pl.col("name").str.split("-").arr.to_struct(upper_bound=2, fields=["coassembly", "genome"])
+        pl.col("name").str.split("-").list.to_struct(upper_bound=2, fields=["coassembly", "genome"])
     ).unnest("name"
     ).groupby("coassembly"
     ).agg(

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -52,7 +52,7 @@ def pipeline(
         for _ in range(1, MAX_COASSEMBLY_SAMPLES):
             dfs.append(
                 dfs[-1]
-                .join(df.lazy(), on="target", how="left", suffix="_2")
+                .join(df.lazy(), how="cross", suffix="_2")
                 .filter(
                     (pl.col("samples").arr.contains(pl.col("samples_2").arr.first()).is_not()) &
                     (pl.col("samples").arr.last().str.encode("hex") < pl.col("samples_2").arr.first().str.encode("hex"))

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -116,6 +116,12 @@ if __name__ == "__main__":
     os.environ["POLARS_MAX_THREADS"] = str(snakemake.threads)
     import polars as pl
 
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s: %(message)s',
+        datefmt='%Y/%m/%d %I:%M:%S %p'
+        )
+
     MIN_COASSEMBLY_COVERAGE = snakemake.params.min_coassembly_coverage
     MAX_COASSEMBLY_SAMPLES = snakemake.params.max_coassembly_samples
     TAXA_OF_INTEREST = snakemake.params.taxa_of_interest

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -49,7 +49,7 @@ def pipeline(
 
     def process_groups(df):
         if df.height == 1:
-            return pl.DataFrame(schema={"target": str, "coverage": int, "samples": str})
+            return pl.DataFrame(schema={"target": str, "coverage": float, "samples": str})
 
         dfs = [df.lazy()]
         for _ in range(1, MAX_COASSEMBLY_SAMPLES):

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -57,13 +57,13 @@ def pipeline(
                 dfs[-1]
                 .join(df.lazy(), how="cross", suffix="_2")
                 .filter(
-                    (pl.col("samples").arr.contains(pl.col("samples_2").arr.first()).is_not()) &
-                    (pl.col("samples").arr.last().str.encode("hex") < pl.col("samples_2").arr.first().str.encode("hex"))
+                    (pl.col("samples").list.contains(pl.col("samples_2").list.first()).is_not()) &
+                    (pl.col("samples").list.last().str.encode("hex") < pl.col("samples_2").list.first().str.encode("hex"))
                     )
                 .select([
                     "target",
                     pl.col("coverage") + pl.col("coverage_2").alias("coverage"),
-                    pl.col("samples").arr.concat(pl.col("samples_2")),
+                    pl.col("samples").list.concat(pl.col("samples_2")),
                     ])
             )
 
@@ -71,9 +71,9 @@ def pipeline(
             pl.concat(
                 pl.collect_all(dfs)
                 )
-            .filter(pl.col("samples").arr.lengths() > 1)
+            .filter(pl.col("samples").list.lengths() > 1)
             .filter(pl.col("coverage") > MIN_COASSEMBLY_COVERAGE)
-            .with_columns(pl.col("samples").arr.join(","))
+            .with_columns(pl.col("samples").list.join(","))
         )
 
         return filtered

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -49,7 +49,7 @@ def pipeline(
 
     def process_groups(df):
         if df.height == 1:
-            return pl.DataFrame(schema=["target", "samples", "coverage"])
+            return pl.DataFrame(schema={"target": str, "coverage": int, "samples": str})
 
         dfs = [df.lazy()]
         for _ in range(1, MAX_COASSEMBLY_SAMPLES):

--- a/ibis/workflow/scripts/target_elusive.py
+++ b/ibis/workflow/scripts/target_elusive.py
@@ -48,6 +48,9 @@ def pipeline(
     )
 
     def process_groups(df):
+        if df.height == 1:
+            return pl.DataFrame(schema=["target", "samples", "coverage"])
+
         dfs = [df.lazy()]
         for _ in range(1, MAX_COASSEMBLY_SAMPLES):
             dfs.append(

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -289,8 +289,8 @@ class Tests(unittest.TestCase):
             ["match", 2, "4,5", "6,7"],
             ["match", 2, "4,6", "8,9"],
             ["match", 2, "5,6", "10,11,12"],
-            ["pool", 3, "1,2,3", 2, "1,3"],
-            ["pool", 3, "4,5,6", 1, "6"],
+            ["pool", 3, "1,2,3", "1,3"],
+            ["pool", 3, "4,5,6", "6"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -454,11 +454,12 @@ class Tests(unittest.TestCase):
 
             df2 = (
                 pl.DataFrame([
-                        [["a", "b"], ["1"]],
-                        [["b", "c"], ["2"]],
-                        [["c", "d"], ["3"]],
-                        [["b", "c", "d"], ["4"]],
-                    ], schema=["samples", "target_ids"])
+                        [["a", "b"], ["1"], 2],
+                        [["b", "c"], ["2"], 2],
+                        [["c", "d"], ["3"], 2],
+                        [["b", "c", "d"], ["4"], 3],
+                        [["b", "c", "d", "g"], ["5"], 3],
+                    ], schema=["samples", "target_ids", "cluster_size"])
                 .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
                 .with_columns(samples_hash = pl.col("samples").list.sort().hash())
             )
@@ -466,8 +467,8 @@ class Tests(unittest.TestCase):
             expected = (
                 pl.DataFrame([
                         [["a", "b", "c"], ["1"], ["1", "2"]],
-                        [["b", "c", "d"], ["2"], ["2", "3", "4"]],
-                        [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
+                        [["b", "c", "d"], ["2"], ["2", "3", "4", "5"]],
+                        [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4", "5"]],
                         [["d", "e", "f"], ["4"], []],
                     ], schema=["samples", "target_ids", "extra_targets"])
                 .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
@@ -497,11 +498,12 @@ class Tests(unittest.TestCase):
 
             df2 = (
                 pl.DataFrame([
-                        [["a", "b"], ["1"]],
-                        [["b", "c"], ["2"]],
-                        [["c", "d"], ["3"]],
-                        [["b", "c", "d"], ["4"]],
-                    ], schema=["samples", "target_ids"])
+                        [["a", "b"], ["1"], 2],
+                        [["b", "c"], ["2"], 2],
+                        [["c", "d"], ["3"], 2],
+                        [["b", "c", "d"], ["4"], 3],
+                        [["b", "c", "d", "g"], ["5"], 3],
+                    ], schema=["samples", "target_ids", "cluster_size"])
                 .lazy()
                 .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
                 .with_columns(samples_hash = pl.col("samples").list.sort().hash())
@@ -510,8 +512,8 @@ class Tests(unittest.TestCase):
             expected = (
                 pl.DataFrame([
                         [["a", "b", "c"], ["1"], ["1", "2"]],
-                        [["b", "c", "d"], ["2"], ["2", "3", "4"]],
-                        [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
+                        [["b", "c", "d"], ["2"], ["2", "3", "4", "5"]],
+                        [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4", "5"]],
                         [["d", "e", "f"], ["4"], []],
                     ], schema=["samples", "target_ids", "extra_targets"])
                 .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -454,7 +454,7 @@ class Tests(unittest.TestCase):
             self.assertDataFrameEqual(expected, observed)
 
     def test_accumulate_clusters(self):
-        input = ["1,2,3", "1,2,4", "4,5,6", "4,5,7", "7,8,9", "7,8,10", "10,11,12", "10,11"]
+        input = [[1,2,3], [1,2,4], [4,5,6], [4,5,7], [7,8,9], [7,8,10], [10,11,12], [10,11]]
 
         expected = pl.Series([True, False, True, False, True, False, True, False], dtype=pl.Boolean)
         observed = accumulate_clusters(input)

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -362,7 +362,7 @@ class Tests(unittest.TestCase):
         ], schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["4,5,6", 3, 7, 3000, "4,5,6", "coassembly_0"],
+            ["1,2,3", 3, 3, 3000, "1,2,3", "coassembly_0"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,
@@ -370,7 +370,7 @@ class Tests(unittest.TestCase):
             MAX_RECOVERY_SAMPLES=3,
             MIN_COASSEMBLY_SAMPLES=3,
             MAX_COASSEMBLY_SAMPLES=3,
-            MIN_CLUSTER_TARGETS=5,
+            MIN_CLUSTER_TARGETS=2,
             )
         self.assertDataFrameEqual(expected, observed)
 

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -454,7 +454,7 @@ class Tests(unittest.TestCase):
             self.assertDataFrameEqual(expected, observed)
 
     def test_accumulate_clusters(self):
-        input = ["1,2,3", "1,2", "4,5,6", "4,5", "7,8,9", "7,8", "10,11,12", "10,11"]
+        input = ["1,2,3", "1,2,4", "4,5,6", "4,5,7", "7,8,9", "7,8,10", "10,11,12", "10,11"]
 
         expected = pl.Series([True, False, True, False, True, False, True, False], dtype=pl.Boolean)
         observed = accumulate_clusters(input)

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -337,6 +337,41 @@ class Tests(unittest.TestCase):
             )
         self.assertDataFrameEqual(expected, observed)
 
+    def test_cluster_three_samples_min_cluster(self):
+        elusive_edges = pl.DataFrame([
+            ["match", 2, "1,2", "1,2,3"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "2,3", "1,3"],
+            ["match", 2, "4,1", "4"],
+            ["match", 2, "4,3", "5"],
+            ["match", 2, "4,5", "6,7"],
+            ["match", 2, "4,6", "8,9"],
+            ["match", 2, "5,6", "10,11,12"],
+            ["pool", 3, "1,2,3", "1,3"],
+            ["pool", 3, "4,5,6", "6"],
+        ], schema = ELUSIVE_EDGES_COLUMNS)
+        read_size = pl.DataFrame([
+            ["1", 1000],
+            ["2", 1000],
+            ["3", 1000],
+            ["4", 1000],
+            ["5", 1000],
+            ["6", 1000],
+        ], schema=READ_SIZE_COLUMNS)
+
+        expected = pl.DataFrame([
+            ["4,5,6", 3, 7, 3000, "4,5,6", "coassembly_0"],
+        ], schema=ELUSIVE_CLUSTERS_COLUMNS)
+        observed = pipeline(
+            elusive_edges,
+            read_size,
+            MAX_RECOVERY_SAMPLES=3,
+            MIN_COASSEMBLY_SAMPLES=3,
+            MAX_COASSEMBLY_SAMPLES=3,
+            MIN_CLUSTER_TARGETS=5,
+            )
+        self.assertDataFrameEqual(expected, observed)
+
     def test_cluster_four_samples(self):
         # 1:   2 3 4
         # 2: 1   3 4

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -380,73 +380,75 @@ class Tests(unittest.TestCase):
         self.assertDataFrameEqual(expected, observed)
 
     def test_join_list_subsets(self):
-        df1 = pl.DataFrame([
-            [["a", "b", "c"], ["1"]],
-            [["b", "c", "d"], ["2"]],
-            [["a", "b", "c", "d"], ["3"]],
-            [["d", "e", "f"], ["4"]],
-        ], schema=["col1", "col2"])
+        with pl.StringCache():
+            df1 = pl.DataFrame([
+                [["a", "b", "c"], ["1"]],
+                [["b", "c", "d"], ["2"]],
+                [["a", "b", "c", "d"], ["3"]],
+                [["d", "e", "f"], ["4"]],
+            ], schema=["col1", "col2"])
 
-        df2 = pl.DataFrame([
-            [["a", "b"], ["1"]],
-            [["b", "c"], ["2"]],
-            [["c", "d"], ["3"]],
-            [["b", "c", "d"], ["4"]],
-        ], schema=["col1", "col2"])
+            df2 = pl.DataFrame([
+                [["a", "b"], ["1"]],
+                [["b", "c"], ["2"]],
+                [["c", "d"], ["3"]],
+                [["b", "c", "d"], ["4"]],
+            ], schema=["col1", "col2"])
 
-        expected = pl.DataFrame([
-            [["a", "b", "c"], ["1"], ["1", "2"]],
-            [["b", "c", "d"], ["2"], ["2", "3", "4"]],
-            [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
-            [["d", "e", "f"], ["4"], []],
-        ], schema=["col1", "col2", "col3"])
+            expected = pl.DataFrame([
+                [["a", "b", "c"], ["1"], ["1", "2"]],
+                [["b", "c", "d"], ["2"], ["2", "3", "4"]],
+                [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
+                [["d", "e", "f"], ["4"], []],
+            ], schema=["col1", "col2", "col3"])
 
-        observed = (
-            join_list_subsets(
-                df1,
-                df2,
-                list_colname="col1",
-                value_colname="col2",
-                output_colname="col3"
-                )
-            .with_columns(pl.col("col3").list.sort())
-        )
-        self.assertDataFrameEqual(expected, observed)
+            observed = (
+                join_list_subsets(
+                    df1.with_columns(pl.col("col1").cast(pl.List(pl.Categorical))),
+                    df2.with_columns(pl.col("col1").cast(pl.List(pl.Categorical))),
+                    list_colname="col1",
+                    value_colname="col2",
+                    output_colname="col3"
+                    )
+                .with_columns(pl.col("col3").list.sort())
+            )
+            self.assertDataFrameEqual(expected, observed)
 
     def test_join_list_subsets_lazy(self):
-        df1 = pl.DataFrame([
-            [["a", "b", "c"], ["1"]],
-            [["b", "c", "d"], ["2"]],
-            [["a", "b", "c", "d"], ["3"]],
-            [["d", "e", "f"], ["4"]],
-        ], schema=["col1", "col2"]).lazy()
+        with pl.StringCache():
+            df1 = pl.DataFrame([
+                [["a", "b", "c"], ["1"]],
+                [["b", "c", "d"], ["2"]],
+                [["a", "b", "c", "d"], ["3"]],
+                [["d", "e", "f"], ["4"]],
+            ], schema=["col1", "col2"]).lazy()
 
-        df2 = pl.DataFrame([
-            [["a", "b"], ["1"]],
-            [["b", "c"], ["2"]],
-            [["c", "d"], ["3"]],
-            [["b", "c", "d"], ["4"]],
-        ], schema=["col1", "col2"]).lazy()
+            df2 = pl.DataFrame([
+                [["a", "b"], ["1"]],
+                [["b", "c"], ["2"]],
+                [["c", "d"], ["3"]],
+                [["b", "c", "d"], ["4"]],
+            ], schema=["col1", "col2"]).lazy()
 
-        expected = pl.DataFrame([
-            [["a", "b", "c"], ["1"], ["1", "2"]],
-            [["b", "c", "d"], ["2"], ["2", "3", "4"]],
-            [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
-            [["d", "e", "f"], ["4"], []],
-        ], schema=["col1", "col2", "col3"])
+            expected = pl.DataFrame([
+                [["a", "b", "c"], ["1"], ["1", "2"]],
+                [["b", "c", "d"], ["2"], ["2", "3", "4"]],
+                [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
+                [["d", "e", "f"], ["4"], []],
+            ], schema=["col1", "col2", "col3"])
 
-        observed = (
-            join_list_subsets(
-                df1,
-                df2,
-                list_colname="col1",
-                value_colname="col2",
-                output_colname="col3"
-                )
-            .with_columns(pl.col("col3").list.sort())
-            .collect()
-        )
-        self.assertDataFrameEqual(expected, observed)
+            observed = (
+                join_list_subsets(
+                    df1.with_columns(pl.col("col1").cast(pl.List(pl.Categorical))),
+                    df2.with_columns(pl.col("col1").cast(pl.List(pl.Categorical))),
+                    list_colname="col1",
+                    value_colname="col2",
+                    output_colname="col3"
+                    )
+                .with_columns(pl.col("col3").list.sort())
+                .collect()
+            )
+            self.assertDataFrameEqual(expected, observed)
 
 
 if __name__ == '__main__':

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -31,7 +31,7 @@ CAT_CLUSTERS_COLUMNS={
     "total_size": int,
     }
 SAMPLE_TARGETS_COLUMNS={
-    "samples": pl.Utf8,
+    "recover_candidates": pl.Utf8,
     "target_ids": pl.List(pl.UInt32),
     }
 CAT_RECOVERY_COLUMNS={
@@ -508,7 +508,7 @@ class Tests(unittest.TestCase):
                     ],
                     schema=SAMPLE_TARGETS_COLUMNS
                     )
-                .with_columns(pl.col("samples").cast(pl.Categorical))
+                .with_columns(pl.col("recover_candidates").cast(pl.Categorical))
             )
 
             clusters = (
@@ -565,7 +565,7 @@ class Tests(unittest.TestCase):
                     ],
                     schema=SAMPLE_TARGETS_COLUMNS
                     )
-                .with_columns(pl.col("samples").cast(pl.Categorical))
+                .with_columns(pl.col("recover_candidates").cast(pl.Categorical))
                 .lazy()
             )
 

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -476,7 +476,14 @@ class Tests(unittest.TestCase):
     def test_accumulate_clusters(self):
         input = [[1,2,3], [1,2,4], [4,5,6], [4,5,7], [7,8,9], [7,8,10], [10,11,12], [10,11]]
 
-        expected = pl.Series([True, False, True, False, True, False, True, False], dtype=pl.Boolean)
+        expected = pl.Series([True, False, True, False, True, False, True, True], dtype=pl.Boolean)
+        observed = accumulate_clusters(input)
+        self.assertSeriesEqual(observed, expected)
+
+    def test_accumulate_clusters_diff_sample_sizes(self):
+        input = [[1,2,3], [1,2], [1,2,4], [2,3], [4,5,6], [3,4], [4,5,7], [4,5], [7,8,9], [7,8,10], [10,11,12], [10,11], [1,2,3,4], [1,2,3,4,5], [1,2,3,4,5,6]]
+
+        expected = pl.Series([True, True, False, False, True, True, False, False, True, False, True, True, True, True, True], dtype=pl.Boolean)
         observed = accumulate_clusters(input)
         self.assertSeriesEqual(observed, expected)
 

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -259,7 +259,7 @@ class Tests(unittest.TestCase):
         ], schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["1,2", 2, 1, 2000, "1,2", "coassembly_0"],
+            ["1,2", 2, 2, 2000, "1,2", "coassembly_0"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(elusive_edges, read_size)
         self.assertDataFrameEqual(expected, observed)

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -362,7 +362,7 @@ class Tests(unittest.TestCase):
         ], schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["1,2,3", 3, 3, 3000, "1,2,3", "coassembly_0"],
+            ["4,5,6", 3, 7, 3000, "4,5,6", "coassembly_0"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,
@@ -370,7 +370,7 @@ class Tests(unittest.TestCase):
             MAX_RECOVERY_SAMPLES=3,
             MIN_COASSEMBLY_SAMPLES=3,
             MAX_COASSEMBLY_SAMPLES=3,
-            MIN_CLUSTER_TARGETS=2,
+            MIN_CLUSTER_TARGETS=5,
             )
         self.assertDataFrameEqual(expected, observed)
 

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -8,8 +8,9 @@ from polars.testing import assert_frame_equal
 from ibis.workflow.scripts.cluster_graph import pipeline
 
 ELUSIVE_EDGES_COLUMNS={
+    "style": str,
+    "cluster_size": int,
     "samples": str,
-    "weight": int,
     "target_ids": str,
     }
 READ_SIZE_COLUMNS=["sample", "read_size"]
@@ -28,8 +29,8 @@ class Tests(unittest.TestCase):
 
     def test_cluster_graph(self):
         elusive_edges = pl.DataFrame([
-            ["sample_2.1,sample_1.1", 3, "0,1,2"],
-            ["sample_1.1,sample_3.1", 2, "1,2"],
+            ["match", 2, "sample_2.1,sample_1.1", "0,1,2"],
+            ["match", 2, "sample_1.1,sample_3.1", "1,2"],
         ], schema=ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["sample_1", 1000],
@@ -45,12 +46,12 @@ class Tests(unittest.TestCase):
 
     def test_cluster_two_components(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 1, "1"],
-            ["1,3", 2, "1,2"],
-            ["2,3", 3, "1,2,3"],
-            ["4,5", 4, "4,5,6,7"],
-            ["4,6", 5, "4,5,6,7,8"],
-            ["5,6", 6, "4,5,6,7,8,9"],
+            ["match", 2, "1,2", "1"],
+            ["match", 2, "1,3", "1,2"],
+            ["match", 2, "2,3", "1,2,3"],
+            ["match", 2, "4,5", "4,5,6,7"],
+            ["match", 2, "4,6", "4,5,6,7,8"],
+            ["match", 2, "5,6", "4,5,6,7,8,9"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -70,13 +71,13 @@ class Tests(unittest.TestCase):
 
     def test_cluster_single_bud(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 2, "1,2"],
-            ["1,3", 2, "1,3"],
-            ["1,4", 2, "1,4"],
-            ["2,3", 2, "2,3"],
-            ["2,4", 2, "2,4"],
-            ["3,4", 2, "3,4"],
-            ["4,5", 1, "5"],
+            ["match", 2, "1,2", "1,2"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "1,4", "1,4"],
+            ["match", 2, "2,3", "2,3"],
+            ["match", 2, "2,4", "2,4"],
+            ["match", 2, "3,4", "3,4"],
+            ["match", 2, "4,5", "5"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -104,9 +105,9 @@ class Tests(unittest.TestCase):
 
     def test_cluster_single_bud_choice(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 4, "1,2,3,4"],
-            ["3,1", 1, "5"],
-            ["3,2", 2, "6,7"],
+            ["match", 2, "1,2", "1,2,3,4"],
+            ["match", 2, "3,1", "5"],
+            ["match", 2, "3,2", "6,7"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -130,15 +131,15 @@ class Tests(unittest.TestCase):
 
     def test_cluster_double_bud(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 3, "1,2,3"],
-            ["1,3", 2, "1,3"],
-            ["1,4", 2, "1,4"],
-            ["2,3", 2, "2,3"],
-            ["2,4", 2, "2,4"],
-            ["3,4", 3, "1,3,4"],
-            ["4,5", 1, "5"],
-            ["4,6", 1, "5"],
-            ["5,6", 3, "5,6,7"],
+            ["match", 2, "1,2", "1,2,3"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "1,4", "1,4"],
+            ["match", 2, "2,3", "2,3"],
+            ["match", 2, "2,4", "2,4"],
+            ["match", 2, "3,4", "1,3,4"],
+            ["match", 2, "4,5", "5"],
+            ["match", 2, "4,6", "5"],
+            ["match", 2, "5,6", "5,6,7"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -163,14 +164,14 @@ class Tests(unittest.TestCase):
 
     def test_cluster_double_bud_choice(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 3, "1,2,3"],
-            ["1,3", 2, "1,3"],
-            ["2,3", 2, "1,3"],
-            ["4,1", 1, "4"],
-            ["4,3", 1, "5"],
-            ["5,1", 1, "4"],
-            ["5,3", 1, "6"],
-            ["4,5", 3, "4,5,6"],
+            ["match", 2, "1,2", "1,2,3"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "2,3", "1,3"],
+            ["match", 2, "4,1", "4"],
+            ["match", 2, "4,3", "5"],
+            ["match", 2, "5,1", "4"],
+            ["match", 2, "5,3", "6"],
+            ["match", 2, "4,5", "4,5,6"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -193,14 +194,14 @@ class Tests(unittest.TestCase):
 
     def test_cluster_double_bud_irrelevant_targets(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 3, "1,2,3"],
-            ["1,3", 2, "1,3"],
-            ["2,3", 2, "1,3"],
-            ["4,1", 1, "4"],
-            ["4,3", 1, "7"],
-            ["5,1", 1, "4"],
-            ["5,3", 1, "8"],
-            ["4,5", 3, "4,5,6"],
+            ["match", 2, "1,2", "1,2,3"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "2,3", "1,3"],
+            ["match", 2, "4,1", "4"],
+            ["match", 2, "4,3", "7"],
+            ["match", 2, "5,1", "4"],
+            ["match", 2, "5,3", "8"],
+            ["match", 2, "4,5", "4,5,6"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -223,7 +224,7 @@ class Tests(unittest.TestCase):
 
     def test_cluster_two_samples_among_many(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 1, "some"],
+            ["match", 2, "1,2", "some"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -259,7 +260,7 @@ class Tests(unittest.TestCase):
 
     def test_cluster_only_large_clusters(self):
         elusive_edges = pl.DataFrame([
-            ["1,2", 1, "some"],
+            ["match", 2, "1,2", "some"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 10000],
@@ -280,16 +281,16 @@ class Tests(unittest.TestCase):
         # 6:           6   8 9 10 11 12
 
         elusive_edges = pl.DataFrame([
-            ["1,2", 3, "1,2,3"],
-            ["1,3", 2, "1,3"],
-            ["2,3", 2, "1,3"],
-            ["4,1", 1, "4"],
-            ["4,3", 1, "5"],
-            ["4,5", 2, "6,7"],
-            ["4,6", 2, "8,9"],
-            ["5,6", 3, "10,11,12"],
-            ["1,2,3", 2, "1,3"],
-            ["4,5,6", 1, "6"],
+            ["match", 2, "1,2", "1,2,3"],
+            ["match", 2, "1,3", "1,3"],
+            ["match", 2, "2,3", "1,3"],
+            ["match", 2, "4,1", "4"],
+            ["match", 2, "4,3", "5"],
+            ["match", 2, "4,5", "6,7"],
+            ["match", 2, "4,6", "8,9"],
+            ["match", 2, "5,6", "10,11,12"],
+            ["pool", 3, "1,2,3", 2, "1,3"],
+            ["pool", 3, "4,5,6", 1, "6"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -326,43 +327,33 @@ class Tests(unittest.TestCase):
 
         elusive_edges = pl.DataFrame([
             # pairs of 1,2,3,4
-            ["1,2", 2, "3,4"],
-            ["1,3", 2, "2,4"],
-            ["1,4", 3, "2,3,4"],
-            ["2,3", 2, "1,4"],
-            ["2,4", 3, "1,3,4"],
-            ["3,4", 3, "1,2,4"],
-            # triplets of 1,2,3,4
-            ["1,2,3", 1, "4"],
-            ["1,2,4", 2, "3,4"],
-            ["1,3,4", 2, "2,4"],
-            ["2,3,4", 2, "1,4"],
-            # quads of 1,2,3,4
-            ["1,2,3,4", 1, "4"],
+            ["match", 2, "1,2", "3,4"],
+            ["match", 2, "1,3", "2,4"],
+            ["match", 2, "1,4", "2,3,4"],
+            ["match", 2, "2,3", "1,4"],
+            ["match", 2, "2,4", "1,3,4"],
+            ["match", 2, "3,4", "1,2,4"],
             # pairs of 5,6,7,8
-            ["5,6", 2, "7,8"],
-            ["5,7", 2, "6,8"],
-            ["5,8", 3, "8,9,10"],
-            ["6,7", 2, "5,8"],
-            ["6,8", 1, "8"],
-            ["7,8", 1, "8"],
-            # triplets of 5,6,7,8
-            ["5,6,7", 1, "8"],
-            ["5,6,8", 1, "8"],
-            ["5,7,8", 1, "8"],
-            ["6,7,8", 1, "8"],
-            # quads of 5,6,7,8
-            ["5,6,7,8", 1, "8"],
+            ["match", 2, "5,6", "7,8"],
+            ["match", 2, "5,7", "6,8"],
+            ["match", 2, "5,8", "8,9,10"],
+            ["match", 2, "6,7", "5,8"],
+            ["match", 2, "6,8", "8"],
+            ["match", 2, "7,8", "8"],
             # joint pairs
-            ["2,5", 1, "1"],
-            ["3,5", 1, "1"],
-            ["4,5", 1, "1"],
-            # joint triplets
-            ["2,3,5", 1, "1"],
-            ["2,4,5", 1, "1"],
-            ["3,4,5", 1, "1"],
-            # joint quads
-            ["2,3,4,5", 1, "1"],
+            ["match", 2, "2,5", "1"],
+            ["match", 2, "3,5", "1"],
+            ["match", 2, "4,5", "1"],
+            # triplets
+            ["pool", 3, "2,3,4,5", "1"],
+            ["pool", 3, "1,3,4", "2"],
+            ["pool", 3, "1,2,4", "3"],
+            ["pool", 3, "1,2,3,4", "4"],
+            ["pool", 3, "5,6,7,8", "8"],
+            # quads
+            ["pool", 4, "2,3,4,5", "1"],
+            ["pool", 4, "1,2,3,4", "4"],
+            ["pool", 4, "5,6,7,8", "8"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -360,7 +360,7 @@ class Tests(unittest.TestCase):
         ], schema=READ_SIZE_COLUMNS)
 
         expected = pl.DataFrame([
-            ["4,5,6", 3, 7, 3000, "4,5,6", "coassembly_0"],
+            ["1,2,3", 3, 3, 3000, "1,2,3", "coassembly_0"],
         ], schema=ELUSIVE_CLUSTERS_COLUMNS)
         observed = pipeline(
             elusive_edges,
@@ -368,7 +368,7 @@ class Tests(unittest.TestCase):
             MAX_RECOVERY_SAMPLES=3,
             MIN_COASSEMBLY_SAMPLES=3,
             MAX_COASSEMBLY_SAMPLES=3,
-            MIN_CLUSTER_TARGETS=5,
+            MIN_CLUSTER_TARGETS=2,
             )
         self.assertDataFrameEqual(expected, observed)
 

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -247,7 +247,7 @@ class Tests(unittest.TestCase):
 
     def test_cluster_two_samples_among_many(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "some"],
+            ["match", 2, "1,2", "9,10"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 1000],
@@ -283,7 +283,7 @@ class Tests(unittest.TestCase):
 
     def test_cluster_only_large_clusters(self):
         elusive_edges = pl.DataFrame([
-            ["match", 2, "1,2", "some"],
+            ["match", 2, "1,2", "9,10"],
         ], schema = ELUSIVE_EDGES_COLUMNS)
         read_size = pl.DataFrame([
             ["1", 10000],

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -388,10 +388,10 @@ class Tests(unittest.TestCase):
         ], schema=["col1", "col2"])
 
         df2 = pl.DataFrame([
-            [["a", "b"], "1"],
-            [["b", "c"], "2"],
-            [["c", "d"], "3"],
-            [["b", "c", "d"], "4"],
+            [["a", "b"], ["1"]],
+            [["b", "c"], ["2"]],
+            [["c", "d"], ["3"]],
+            [["b", "c", "d"], ["4"]],
         ], schema=["col1", "col2"])
 
         expected = pl.DataFrame([
@@ -422,10 +422,10 @@ class Tests(unittest.TestCase):
         ], schema=["col1", "col2"]).lazy()
 
         df2 = pl.DataFrame([
-            [["a", "b"], "1"],
-            [["b", "c"], "2"],
-            [["c", "d"], "3"],
-            [["b", "c", "d"], "4"],
+            [["a", "b"], ["1"]],
+            [["b", "c"], ["2"]],
+            [["c", "d"], ["3"]],
+            [["b", "c", "d"], ["4"]],
         ], schema=["col1", "col2"]).lazy()
 
         expected = pl.DataFrame([

--- a/test/test_cluster_graph.py
+++ b/test/test_cluster_graph.py
@@ -447,9 +447,9 @@ class Tests(unittest.TestCase):
                         [["b", "c", "d"], ["2"]],
                         [["a", "b", "c", "d"], ["3"]],
                         [["d", "e", "f"], ["4"]],
-                    ], schema=["col1", "col2"])
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
+                    ], schema=["samples", "target_ids"])
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
             )
 
             df2 = (
@@ -458,9 +458,9 @@ class Tests(unittest.TestCase):
                         [["b", "c"], ["2"]],
                         [["c", "d"], ["3"]],
                         [["b", "c", "d"], ["4"]],
-                    ], schema=["col1", "col2"])
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
+                    ], schema=["samples", "target_ids"])
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
             )
 
             expected = (
@@ -469,22 +469,15 @@ class Tests(unittest.TestCase):
                         [["b", "c", "d"], ["2"], ["2", "3", "4"]],
                         [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
                         [["d", "e", "f"], ["4"], []],
-                    ], schema=["col1", "col2", "col3"])
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
-                .select("col1", "col2", "hash", "col3")
+                    ], schema=["samples", "target_ids", "extra_targets"])
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
+                .select("samples", "target_ids", "samples_hash", "extra_targets")
             )
 
             observed = (
-                join_list_subsets(
-                    df1,
-                    df2,
-                    hash_colname="hash",
-                    list_colname="col1",
-                    value_colname="col2",
-                    output_colname="col3"
-                    )
-                .with_columns(pl.col("col3").list.sort())
+                join_list_subsets(df1, df2)
+                .with_columns(pl.col("extra_targets").list.sort())
             )
             self.assertDataFrameEqual(expected, observed)
 
@@ -496,10 +489,10 @@ class Tests(unittest.TestCase):
                         [["b", "c", "d"], ["2"]],
                         [["a", "b", "c", "d"], ["3"]],
                         [["d", "e", "f"], ["4"]],
-                    ], schema=["col1", "col2"])
+                    ], schema=["samples", "target_ids"])
                 .lazy()
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
             )
 
             df2 = (
@@ -508,10 +501,10 @@ class Tests(unittest.TestCase):
                         [["b", "c"], ["2"]],
                         [["c", "d"], ["3"]],
                         [["b", "c", "d"], ["4"]],
-                    ], schema=["col1", "col2"])
+                    ], schema=["samples", "target_ids"])
                 .lazy()
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
             )
 
             expected = (
@@ -520,22 +513,15 @@ class Tests(unittest.TestCase):
                         [["b", "c", "d"], ["2"], ["2", "3", "4"]],
                         [["a", "b", "c", "d"], ["3"], ["1", "2", "3", "4"]],
                         [["d", "e", "f"], ["4"], []],
-                    ], schema=["col1", "col2", "col3"])
-                .with_columns(pl.col("col1").cast(pl.List(pl.Categorical)))
-                .with_columns(hash = pl.col("col1").list.sort().hash())
-                .select("col1", "col2", "hash", "col3")
+                    ], schema=["samples", "target_ids", "extra_targets"])
+                .with_columns(pl.col("samples").cast(pl.List(pl.Categorical)))
+                .with_columns(samples_hash = pl.col("samples").list.sort().hash())
+                .select("samples", "target_ids", "samples_hash", "extra_targets")
             )
 
             observed = (
-                join_list_subsets(
-                    df1,
-                    df2,
-                    hash_colname="hash",
-                    list_colname="col1",
-                    value_colname="col2",
-                    output_colname="col3"
-                    )
-                .with_columns(pl.col("col3").list.sort())
+                join_list_subsets(df1, df2)
+                .with_columns(pl.col("extra_targets").list.sort())
                 .collect()
             )
             self.assertDataFrameEqual(expected, observed)

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -33,10 +33,16 @@ ELUSIVE_CLUSTERS_TWO = os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters
 
 
 class Tests(unittest.TestCase):
-    def test_update_sra_download_real(self):
-        output_dir = os.path.join("examples", "test_update_sra_download_real")
-        shutil.rmtree(output_dir)
+    def setup_output_dir(self, output_dir):
+        try:
+            shutil.rmtree(output_dir)
+        except FileNotFoundError:
+            pass
         os.makedirs(output_dir)
+
+    def test_update_sra_download_real(self):
+        output_dir = os.path.join("example", "test_update_sra_download_real")
+        self.setup_output_dir(output_dir)
 
         cmd = (
             f"ibis update "
@@ -67,9 +73,8 @@ class Tests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
     def test_update_aviary_run_real(self):
-        output_dir = os.path.join("examples", "test_update_aviary_run_real")
-        shutil.rmtree(output_dir)
-        os.makedirs(output_dir)
+        output_dir = os.path.join("example", "test_update_aviary_run_real")
+        self.setup_output_dir(output_dir)
 
         cmd = (
             f"ibis update "
@@ -111,9 +116,8 @@ class Tests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "recover", "bins", "checkm_minimal.tsv")))
 
     def test_update_specific_coassembly_sra(self):
-        output_dir = os.path.join("examples", "test_update_specific_coassembly_sra")
-        shutil.rmtree(output_dir)
-        os.makedirs(output_dir)
+        output_dir = os.path.join("example", "test_update_specific_coassembly_sra")
+        self.setup_output_dir(output_dir)
 
         cmd = (
             f"ibis update "

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -58,19 +58,19 @@ class Tests(unittest.TestCase):
         )
         extern.run(cmd)
 
-        config_path = os.path.join("test", "config.yaml")
+        config_path = os.path.join(output_dir, "config.yaml")
         self.assertTrue(os.path.exists(config_path))
 
-        sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
+        sra_1_path = os.path.join(output_dir, "coassemble", "sra", "SRR8334323_1.fastq.gz")
         self.assertTrue(os.path.exists(sra_1_path))
         with gzip.open(sra_1_path) as f:
             file = f.readline().decode()
             self.assertTrue("@SRR8334323.1 HS2:487:H80UEADXX:1:1101:1148:1986/1" in file)
             self.assertTrue("@SRR8334323.2 HS2:487:H80UEADXX:1:1101:1148:1986/2" not in file)
 
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
     def test_update_aviary_run_real(self):
         output_dir = os.path.join("example", "test_update_aviary_run_real")
@@ -97,23 +97,23 @@ class Tests(unittest.TestCase):
         )
         extern.run(cmd)
 
-        config_path = os.path.join("test", "config.yaml")
+        config_path = os.path.join(output_dir, "config.yaml")
         self.assertTrue(os.path.exists(config_path))
 
-        sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
+        sra_1_path = os.path.join(output_dir, "coassemble", "sra", "SRR8334323_1.fastq.gz")
         self.assertTrue(os.path.exists(sra_1_path))
         with gzip.open(sra_1_path) as f:
             file = f.readline().decode()
             self.assertTrue("@SRR8334323.1 1/1" in file)
             self.assertTrue("@SRR8334323.1 1/2" not in file)
 
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "assemble", "assembly", "final_contigs.fna")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "coassemble", "coassembly_0", "assemble", "assembly", "final_contigs.fna")))
 
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "recover", "bins", "checkm_minimal.tsv")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "coassemble", "coassembly_0", "recover", "bins", "checkm_minimal.tsv")))
 
     def test_update_specific_coassembly_sra(self):
         output_dir = os.path.join("example", "test_update_specific_coassembly_sra")
@@ -133,18 +133,18 @@ class Tests(unittest.TestCase):
         )
         output = extern.run(cmd)
 
-        config_path = os.path.join("test", "config.yaml")
+        config_path = os.path.join(output_dir, "config.yaml")
         self.assertTrue(os.path.exists(config_path))
 
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334323_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
-        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_1.fastq.gz")))
-        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_2.fastq.gz")))
-        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_1.fastq.gz")))
-        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_2.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334320_1.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334320_2.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334321_1.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "coassemble", "sra", "SRR8334321_2.fastq.gz")))
 
 
 if __name__ == '__main__':

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -2,8 +2,8 @@
 
 import unittest
 import os
+import shutil
 import gzip
-from bird_tool_utils import in_tempdir
 import extern
 
 path_to_data = os.path.join(os.path.dirname(os.path.realpath(__file__)),'data')
@@ -34,104 +34,113 @@ ELUSIVE_CLUSTERS_TWO = os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters
 
 class Tests(unittest.TestCase):
     def test_update_sra_download_real(self):
-        with in_tempdir():
-            cmd = (
-                f"ibis update "
-                f"--assemble-unmapped "
-                f"--forward SRR8334323 SRR8334324 "
-                f"--sra "
-                f"--genomes {GENOMES} "
-                f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
-                f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
-                f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra.tsv')} "
-                f"--output test "
-                f"--conda-prefix {path_to_conda} "
-            )
-            extern.run(cmd)
+        output_dir = os.path.join("examples", "test_update_sra_download_real")
+        shutil.rmtree(output_dir)
+        os.makedirs(output_dir)
 
-            config_path = os.path.join("test", "config.yaml")
-            self.assertTrue(os.path.exists(config_path))
+        cmd = (
+            f"ibis update "
+            f"--assemble-unmapped "
+            f"--forward SRR8334323 SRR8334324 "
+            f"--sra "
+            f"--genomes {GENOMES} "
+            f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
+            f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
+            f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra.tsv')} "
+            f"--output {output_dir} "
+            f"--conda-prefix {path_to_conda} "
+        )
+        extern.run(cmd)
 
-            sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
-            self.assertTrue(os.path.exists(sra_1_path))
-            with gzip.open(sra_1_path) as f:
-                file = f.readline().decode()
-                self.assertTrue("@SRR8334323.1 HS2:487:H80UEADXX:1:1101:1148:1986/1" in file)
-                self.assertTrue("@SRR8334323.2 HS2:487:H80UEADXX:1:1101:1148:1986/2" not in file)
+        config_path = os.path.join("test", "config.yaml")
+        self.assertTrue(os.path.exists(config_path))
 
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
+        self.assertTrue(os.path.exists(sra_1_path))
+        with gzip.open(sra_1_path) as f:
+            file = f.readline().decode()
+            self.assertTrue("@SRR8334323.1 HS2:487:H80UEADXX:1:1101:1148:1986/1" in file)
+            self.assertTrue("@SRR8334323.2 HS2:487:H80UEADXX:1:1101:1148:1986/2" not in file)
+
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
     def test_update_aviary_run_real(self):
-        with in_tempdir():
-            cmd = (
-                f"ibis update "
-                f"--assemble-unmapped "
-                f"--forward SRR8334323 SRR8334324 "
-                f"--sra "
-                f"--run-aviary "
-                f"--cores 32 "
-                f"--aviary-cores 32 "
-                f"--aviary-memory 500 "
-                f"--aviary-gtdbtk-dir /work/microbiome/db/gtdb/gtdb_release207_v2 "
-                f"--aviary-checkm2-dir /work/microbiome/db/CheckM2_database "
-                f"--genomes {GENOMES} "
-                f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
-                f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
-                f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra.tsv')} "
-                f"--output test "
-                f"--conda-prefix {path_to_conda} "
-                f"--snakemake-args \" --config test=True\" "
-            )
-            extern.run(cmd)
+        output_dir = os.path.join("examples", "test_update_aviary_run_real")
+        shutil.rmtree(output_dir)
+        os.makedirs(output_dir)
 
-            config_path = os.path.join("test", "config.yaml")
-            self.assertTrue(os.path.exists(config_path))
+        cmd = (
+            f"ibis update "
+            f"--assemble-unmapped "
+            f"--forward SRR8334323 SRR8334324 "
+            f"--sra "
+            f"--run-aviary "
+            f"--cores 32 "
+            f"--aviary-cores 32 "
+            f"--aviary-memory 500 "
+            f"--aviary-gtdbtk-dir /work/microbiome/db/gtdb/gtdb_release207_v2 "
+            f"--aviary-checkm2-dir /work/microbiome/db/CheckM2_database "
+            f"--genomes {GENOMES} "
+            f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
+            f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
+            f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra.tsv')} "
+            f"--output {output_dir} "
+            f"--conda-prefix {path_to_conda} "
+            f"--snakemake-args \" --config test=True\" "
+        )
+        extern.run(cmd)
 
-            sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
-            self.assertTrue(os.path.exists(sra_1_path))
-            with gzip.open(sra_1_path) as f:
-                file = f.readline().decode()
-                self.assertTrue("@SRR8334323.1 1/1" in file)
-                self.assertTrue("@SRR8334323.1 1/2" not in file)
+        config_path = os.path.join("test", "config.yaml")
+        self.assertTrue(os.path.exists(config_path))
 
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        sra_1_path = os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")
+        self.assertTrue(os.path.exists(sra_1_path))
+        with gzip.open(sra_1_path) as f:
+            file = f.readline().decode()
+            self.assertTrue("@SRR8334323.1 1/1" in file)
+            self.assertTrue("@SRR8334323.1 1/2" not in file)
 
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "assemble", "assembly", "final_contigs.fna")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
 
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "recover", "bins", "checkm_minimal.tsv")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "assemble", "assembly", "final_contigs.fna")))
+
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "coassemble", "coassembly_0", "recover", "bins", "checkm_minimal.tsv")))
 
     def test_update_specific_coassembly_sra(self):
-        with in_tempdir():
-            cmd = (
-                f"ibis update "
-                f"--forward SRR8334323 SRR8334324 "
-                f"--sra "
-                f"--genomes {GENOMES} "
-                f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
-                f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
-                f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra_two.tsv')} "
-                f"--coassemblies coassembly_0 "
-                f"--output test "
-                f"--conda-prefix {path_to_conda} "
-            )
-            output = extern.run(cmd)
+        output_dir = os.path.join("examples", "test_update_specific_coassembly_sra")
+        shutil.rmtree(output_dir)
+        os.makedirs(output_dir)
 
-            config_path = os.path.join("test", "config.yaml")
-            self.assertTrue(os.path.exists(config_path))
+        cmd = (
+            f"ibis update "
+            f"--forward SRR8334323 SRR8334324 "
+            f"--sra "
+            f"--genomes {GENOMES} "
+            f"--appraise-binned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'binned_sra.otu_table.tsv')} "
+            f"--appraise-unbinned {os.path.join(MOCK_COASSEMBLE, 'appraise', 'unbinned_sra.otu_table.tsv')} "
+            f"--elusive-clusters {os.path.join(MOCK_COASSEMBLE, 'target', 'elusive_clusters_sra_two.tsv')} "
+            f"--coassemblies coassembly_0 "
+            f"--output {output_dir} "
+            f"--conda-prefix {path_to_conda} "
+        )
+        output = extern.run(cmd)
 
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
-            self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+        config_path = os.path.join("test", "config.yaml")
+        self.assertTrue(os.path.exists(config_path))
 
-            self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_1.fastq.gz")))
-            self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_2.fastq.gz")))
-            self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_1.fastq.gz")))
-            self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334323_2.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_1.fastq.gz")))
+        self.assertTrue(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334324_2.fastq.gz")))
+
+        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_1.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334320_2.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_1.fastq.gz")))
+        self.assertFalse(os.path.exists(os.path.join("test", "coassemble", "sra", "SRR8334321_2.fastq.gz")))
 
 
 if __name__ == '__main__':

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -112,6 +112,28 @@ class Tests(unittest.TestCase):
         self.assertDataFrameEqual(expected_targets, observed_targets)
         self.assertDataFrameEqual(expected_edges, observed_edges)
 
+    def test_target_elusive_multiple_genes_same_sequence(self):
+        unbinned = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],
+            ["S3.2", "sample_1", "AAA", 5, 10, "Root", ""],
+            ["S3.1", "sample_2", "AAA", 5, 10, "Root", ""],
+            ["S3.2", "sample_2", "AAA", 5, 10, "Root", ""],
+        ], schema=APPRAISE_COLUMNS)
+
+        expected_targets = pl.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root", "0"],
+            ["S3.2", "sample_1", "AAA", 5, 10, "Root", "1"],
+            ["S3.1", "sample_2", "AAA", 5, 10, "Root", "0"],
+            ["S3.2", "sample_2", "AAA", 5, 10, "Root", "1"],
+        ], schema=TARGETS_COLUMNS)
+        expected_edges = pl.DataFrame([
+            ["sample_1,sample_2", 2, "0,1"],
+        ], schema=EDGES_COLUMNS)
+
+        observed_targets, observed_edges = pipeline(unbinned)
+        self.assertDataFrameEqual(expected_targets, observed_targets)
+        self.assertDataFrameEqual(expected_edges, observed_edges)
+
     def test_target_elusive_three_sample_mix(self):
         unbinned = pl.DataFrame([
             ["S3.1", "sample_1", "AAA", 5, 10, "Root", ""],

--- a/test/test_target_elusive.py
+++ b/test/test_target_elusive.py
@@ -7,9 +7,25 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from ibis.workflow.scripts.target_elusive import pipeline
 
-APPRAISE_COLUMNS=["gene", "sample", "sequence", "num_hits", "coverage", "taxonomy", "found_in"]
+APPRAISE_COLUMNS={
+    "gene": str,
+    "sample": str,
+    "sequence": str,
+    "num_hits": int,
+    "coverage": float,
+    "taxonomy": str,
+    "found_in": str,
+}
 
-TARGETS_COLUMNS=["gene", "sample", "sequence", "num_hits", "coverage", "taxonomy", "target"]
+TARGETS_COLUMNS={
+    "gene": str,
+    "sample": str,
+    "sequence": str,
+    "num_hits": int,
+    "coverage": float,
+    "taxonomy": str,
+    "target": str,
+}
 EDGES_COLUMNS={
     "samples": str,
     "weight": int,


### PR DESCRIPTION
Requests 95TB of RAM with 2000 samples using recursive method

- [x] switch to groupby on target

Pooled target outputs:
Cons: coverage from one sample can't rescue lower coverage from another
Pros: no combinatorial explosion

- [x] produce rows with lists of samples and N length where any N group of samples have sufficient coverage (e.g. filter based on coverage threshold / N)
- [x] as before for 2-sample clusters
- [x] Update cluster_graph to use new input
- [x] Test again with 2000 sample clustering - failed due to cluster_graph memory

Fix cluster_graph memory issues
- [x] Switch to lazy evaluation
- [x] switch from recursion to itertools.combinations?
- [x] Replace apply with explode join groupby? Might be ok for memory in lazy streaming context.
- [x] Switch to samples as pl.Categorical and targets as pl.UInt32 to preserve memory
- [x] Test again with 2000 sample clustering
- [x] Drop with_row_count from join_list_subsets?
- [x] Fix `not implemented: LargeList` error (only when `is_pooled` is `False`)
~~Switch combinations calculations from `apply` to `for` loop~~