### PR TITLE
Better snakemake cluster support

### DIFF
--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -96,7 +96,7 @@ def run_workflow(config, workflow, output_dir, cores=16, dryrun=False,
 
     cmd = (
         "snakemake --snakefile {snakefile} --configfile '{config}' --directory {output_dir} "
-        "{jobs} --rerun-incomplete --nolock "
+        "{jobs} --rerun-incomplete --keep-going --nolock "
         "--use-conda {conda_frontend} {conda_prefix} "
         "{dryrun} "
         "{snakemake_args} "
@@ -917,7 +917,7 @@ def main():
         argument_group.add_argument("--cores", type=int, help="Maximum number of cores to use", default=1)
         argument_group.add_argument("--dryrun", action="store_true", help="dry run workflow")
         argument_group.add_argument("--snakemake-args", help="Additional commands to be supplied to snakemake in the form of a space-prefixed single string e.g. \" --quiet\"", default="")
-    
+
     def add_base_arguments(argument_group):
         argument_group.add_argument("--forward", "--reads", "--sequences", nargs='+', help="input forward/unpaired nucleotide read sequence(s)")
         argument_group.add_argument("--forward-list", "--reads-list", "--sequences-list", help="input forward/unpaired nucleotide read sequence(s) newline separated")

--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -122,6 +122,8 @@ def download_sra(args):
         "sra": args.forward,
         "reads_1": {},
         "reads_2": {},
+        "snakemake_profile": args.snakemake_profile,
+        "cluster_retries": args.cluster_retries,
     }
 
     config_path = make_config(
@@ -265,6 +267,8 @@ def download_sra(args):
         "sra": [s for s in args.forward if s not in single_ended],
         "reads_1": {},
         "reads_2": {},
+        "snakemake_profile": args.snakemake_profile,
+        "cluster_retries": args.cluster_retries,
     }
 
     config_path = make_config(

--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -478,6 +478,8 @@ def coassemble(args):
         "aviary_threads": args.aviary_cores,
         "aviary_memory": args.aviary_memory,
         "conda_prefix": args.conda_prefix,
+        "snakemake_profile": args.snakemake_profile,
+        "cluster_retries": args.cluster_retries,
     }
 
     config_path = make_config(
@@ -555,6 +557,8 @@ def evaluate(args):
         "cluster": cluster_ani,
         "original_bins": original_bins,
         "prodigal_meta": args.prodigal_meta,
+        "snakemake_profile": args.snakemake_profile,
+        "cluster_retries": args.cluster_retries,
     }
 
     config_path = make_config(

--- a/ibis/workflow/coassemble.smk
+++ b/ibis/workflow/coassemble.smk
@@ -364,9 +364,9 @@ rule download_sra:
         directory(output_dir + "/sra")
     params:
         sra = " ".join(config["sra"]) if config["sra"] else ""
-    threads: 32
+    threads: 4
     resources:
-        mem_mb=250*1000,
+        mem_mb=32*1000,
         runtime = "48h",
     conda:
         "env/kingfisher.yml"

--- a/ibis/workflow/coassemble.smk
+++ b/ibis/workflow/coassemble.smk
@@ -3,7 +3,7 @@
 #############
 ruleorder: no_genomes > query_processing > update_appraise > singlem_appraise
 ruleorder: mock_download_sra > download_sra
-localrules: all, summary, singlem_summarise_genomes, singlem_appraise_filtered, no_genomes, mock_download_sra, compile_sra_qc, collect_genomes, finish_mapping, aviary_commands, aviary_combine
+localrules: all, summary, singlem_summarise_genomes, singlem_appraise_filtered, no_genomes, mock_download_sra, compile_sra_qc, collect_genomes, finish_mapping, aviary_commands, aviary_recover, aviary_combine
 
 import os
 import pandas as pd
@@ -620,6 +620,8 @@ rule aviary_recover:
         checkm2 = config["aviary_checkm2"],
         conda_prefix = config["conda_prefix"] if config["conda_prefix"] else ".",
         fast = "--workflow recover_mags_no_singlem --skip-binners maxbin concoct rosella --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
+        snakemake_profile = f"--snakemake-profile {config["snakemake_profile"]}" if config["snakemake_profile"] else "",
+        cluster_retries = f"--cluster-retries {config["cluster_retries"]}" if config["cluster_retries"] else "",
     threads:
         int(config["aviary_threads"])//2
     resources:
@@ -644,6 +646,8 @@ rule aviary_recover:
         "-n {threads} "
         "-t {threads} "
         "-m {resources.mem_gb} "
+        "{params.snakemake_profile} "
+        "{params.cluster_retries} "
         "{params.dryrun} "
         "&> {log} "
 

--- a/ibis/workflow/coassemble.smk
+++ b/ibis/workflow/coassemble.smk
@@ -620,8 +620,8 @@ rule aviary_recover:
         checkm2 = config["aviary_checkm2"],
         conda_prefix = config["conda_prefix"] if config["conda_prefix"] else ".",
         fast = "--workflow recover_mags_no_singlem --skip-binners maxbin concoct rosella --skip-abundances --refinery-max-iterations 0" if config["aviary_speed"] == FAST_AVIARY_MODE else "",
-        snakemake_profile = f"--snakemake-profile {config["snakemake_profile"]}" if config["snakemake_profile"] else "",
-        cluster_retries = f"--cluster-retries {config["cluster_retries"]}" if config["cluster_retries"] else "",
+        snakemake_profile = f"--snakemake-profile {config['snakemake_profile']}" if config["snakemake_profile"] else "",
+        cluster_retries = f"--cluster-retries {config['cluster_retries']}" if config["cluster_retries"] else "",
     threads:
         int(config["aviary_threads"])//2
     resources:

--- a/ibis/workflow/env/aviary.yml
+++ b/ibis/workflow/env/aviary.yml
@@ -2,5 +2,17 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>=3.7
-  - aviary=0.7.2
+  - python>=3.8
+  - snakemake>=6.0.5
+  - ruamel.yaml>=0.15.99
+  - numpy
+  - pandas
+  - biopython
+  - mamba>=0.8.2
+  - pigz = 2.6
+  - parallel
+  - bbmap
+  - pip
+  - git
+  - pip:
+    - git+https://github.com/rhysnewell/aviary.git@de1a48a

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -110,7 +110,8 @@ class Tests(unittest.TestCase):
             f"--coassemble-summary {os.path.join(MOCK_COASSEMBLE, 'summary.tsv')} "
             f"--output {output_dir} "
             f"--conda-prefix {path_to_conda} "
-            f"--snakemake-args '--profile mqsub --retries 1' "
+            f"--snakemake-profile mqsub "
+            f"--cluster-retries 1 "
         )
         subprocess.run(cmd, shell=True, check=True)
 

--- a/test/test_manual.py
+++ b/test/test_manual.py
@@ -98,6 +98,7 @@ class Tests(unittest.TestCase):
             f"--forward SRR8334323 SRR8334324 "
             f"--sra "
             f"--run-aviary "
+            f"--aviary-speed fast "
             f"--cores 32 "
             f"--aviary-gtdbtk-dir /work/microbiome/db/gtdb/gtdb_release207_v2 "
             f"--aviary-checkm2-dir /work/microbiome/db/CheckM2_database "


### PR DESCRIPTION
- [x] Add snakemake-profile argument
- [x] Add retries argument
- [x] Pass args to Aviary recover to run those rules in separate jobs (but localrules for Aviary recover)
- [x] Aviary assemble is mostly assembly rule, easier to handle metaspades -> megahit on this end, so untouched
- [x] Update Aviary version to cluster-ready commit
- [x] Test manually