### PR TITLE
Restrict polars threads in main

### DIFF
--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -1069,6 +1069,9 @@ def main():
     logging.info(f"Ibis v{__version__}")
     logging.info(f"Command: {' '.join(['ibis'] + sys.argv[1:])}")
 
+    os.environ["POLARS_MAX_THREADS"] = str(args.cores)
+    import polars as pl
+
     args.output = os.path.abspath(args.output)
     if not os.path.exists(args.output):
         os.makedirs(args.output)

--- a/ibis/workflow/scripts/aviary_commands.py
+++ b/ibis/workflow/scripts/aviary_commands.py
@@ -74,6 +74,9 @@ def pipeline(coassemblies, reads_1, reads_2, output_dir, threads, memory, fast=F
     return output.select("assemble", "recover")
 
 if __name__ == "__main__":
+    os.environ["POLARS_MAX_THREADS"] = str(snakemake.threads)
+    import polars as pl
+
     coassemblies = pl.read_csv(snakemake.input.elusive_clusters, separator="\t")
     if coassemblies.height == 0:
         with open(snakemake.output.coassemble_commands, "w") as f:

--- a/ibis/workflow/scripts/aviary_commands.py
+++ b/ibis/workflow/scripts/aviary_commands.py
@@ -3,6 +3,7 @@
 ##########################
 # Author: Samuel Aroney
 
+import os
 import polars as pl
 from ibis.ibis import FAST_AVIARY_MODE
 


### PR DESCRIPTION
Getting pthread_create errors due to reaching RLIMIT_NPROC. Possibly due to too many threads per ibis.py process.