### PR TITLE
Fix QC

### DIFF
--- a/ibis/config/template_coassemble.yaml
+++ b/ibis/config/template_coassemble.yaml
@@ -5,7 +5,7 @@ genomes:
 taxa_of_interest: ""
 max_coassembly_size: 
 assemble_unmapped: false
-read_qc: false
+run_qc: false
 sra: false
 prodigal_meta: false
 single_assembly: false

--- a/ibis/ibis.py
+++ b/ibis/ibis.py
@@ -1113,8 +1113,6 @@ def main():
             raise Exception("Input SingleM query (--sample-query) requires SingleM otu tables (--sample-singlem) for coverage")
         if args.assemble_unmapped and args.single_assembly:
             raise Exception("Assemble unmapped is incompatible with single-sample assembly")
-        if args.run_qc and not args.assemble_unmapped:
-            raise Exception("Run QC requires unmapping (--assemble-unmapped)")
         if args.assemble_unmapped and not args.genomes and not args.genomes_list:
             raise Exception("Reference genomes must be provided to assemble unmapped reads")
         if not args.singlem_metapackage and not os.environ['SINGLEM_METAPACKAGE_PATH'] and not args.sample_query and not args.sample_query_list:

--- a/ibis/workflow/coassemble.smk
+++ b/ibis/workflow/coassemble.smk
@@ -430,7 +430,7 @@ rule qc_reads:
     params:
         quality_cutoff = 15,
         unqualified_percent_limit = 40,
-        min_length = 100,
+        min_length = 80,
     threads: 16
     resources:
         mem_mb=125*1000,

--- a/test/test_coassemble.py
+++ b/test/test_coassemble.py
@@ -235,6 +235,7 @@ class Tests(unittest.TestCase):
                 f"--output test "
                 f"--taxa-of-interest \"p__Actinobacteriota\" "
                 f"--aviary-speed comprehensive "
+                f"--run-qc "
                 f"--conda-prefix {path_to_conda} "
             )
             extern.run(cmd)
@@ -275,6 +276,21 @@ class Tests(unittest.TestCase):
             with open(cluster_path) as f:
                 self.assertEqual(expected, f.read())
 
+            qc_sample_1F_path = os.path.join("test", "coassemble", "qc", "sample_1_1.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_1F_path))
+            qc_sample_1R_path = os.path.join("test", "coassemble", "qc", "sample_1_2.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_1R_path))
+
+            qc_sample_2F_path = os.path.join("test", "coassemble", "qc", "sample_2_1.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_2F_path))
+            qc_sample_2R_path = os.path.join("test", "coassemble", "qc", "sample_2_2.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_2R_path))
+
+            qc_sample_3F_path = os.path.join("test", "coassemble", "qc", "sample_3_1.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_3F_path))
+            qc_sample_3R_path = os.path.join("test", "coassemble", "qc", "sample_3_2.fastq.gz")
+            self.assertTrue(os.path.exists(qc_sample_3R_path))
+
             coassemble_path = os.path.join("test", "coassemble", "commands", "coassemble_commands.sh")
             self.assertTrue(os.path.exists(coassemble_path))
             test_dir = os.path.abspath("test")
@@ -282,11 +298,11 @@ class Tests(unittest.TestCase):
                 [
                     " ".join([
                         "aviary assemble --coassemble -1",
-                        os.path.join(os.path.abspath(path_to_data), "sample_1.1.fq"),
-                        os.path.join(os.path.abspath(path_to_data), "sample_3.1.fq"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_1_1.fastq.gz"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_3_1.fastq.gz"),
                         "-2",
-                        os.path.join(os.path.abspath(path_to_data), "sample_1.2.fq"),
-                        os.path.join(os.path.abspath(path_to_data), "sample_3.2.fq"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_1_2.fastq.gz"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_3_2.fastq.gz"),
                         "--output", os.path.join(test_dir, "coassemble", "coassemble", "coassembly_0", "assemble"),
                         "-n 64 -t 64 -m 500 --skip-qc &>",
                         os.path.join(test_dir, "coassemble", "coassemble", "logs", "coassembly_0_assemble.log"),
@@ -305,11 +321,11 @@ class Tests(unittest.TestCase):
                     " ".join([
                         "aviary recover --assembly", os.path.join(test_dir, "coassemble", "coassemble", "coassembly_0", "assemble", "assembly", "final_contigs.fasta"),
                         "-1",
-                        os.path.join(os.path.abspath(path_to_data), "sample_1.1.fq"),
-                        os.path.join(os.path.abspath(path_to_data), "sample_3.1.fq"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_1_1.fastq.gz"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_3_1.fastq.gz"),
                         "-2",
-                        os.path.join(os.path.abspath(path_to_data), "sample_1.2.fq"),
-                        os.path.join(os.path.abspath(path_to_data), "sample_3.2.fq"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_1_2.fastq.gz"),
+                        os.path.join(test_dir, "coassemble", "qc", "sample_3_2.fastq.gz"),
                         "--output", os.path.join(test_dir, "coassemble", "coassemble", "coassembly_0", "recover"),
                         "-n 32 -t 32 -m 250 --skip-qc &>",
                         os.path.join(test_dir, "coassemble", "coassemble", "logs", "coassembly_0_recover.log"),

--- a/test/test_update.py
+++ b/test/test_update.py
@@ -361,7 +361,7 @@ class Tests(unittest.TestCase):
                 f"--coassemble-summary {MOCK_SUMMARY} "
                 f"--output test "
                 f"--conda-prefix {path_to_conda} "
-                f"--snakemake-args \" --config mock_sra=True\" "
+                f"--snakemake-args \" --config mock_sra=True run_qc=False\" "
             )
             extern.run(cmd)
 


### PR DESCRIPTION
- [x] Update minimum read length to 80 (some SRA are 96x96 reads)
- [x] QC even without unmapping
- [ ] Check QC'd file size: if zero then warning, if a coassemble sample, then error ~ Not easy since QC is now in main Snakemake pipeline. Change to 80 min len should help.
- [ ] Kingfisher SRA download with download files as output so they are removed with failure ~ Can't do since output can be *1.fastq.gz + *2.fastq.gz or just *.fastq.gz